### PR TITLE
Handle newlines in string expressions

### DIFF
--- a/__tests__/__snapshots__/dedent-tests.js.snap
+++ b/__tests__/__snapshots__/dedent-tests.js.snap
@@ -49,6 +49,17 @@ second
 third"
 `;
 
+exports[`dedent works with newlines in interpolation 1`] = `
+"first
+second
+  third
+fourth
+fifth fifth again
+  sixth
+seventh
+eighth"
+`;
+
 exports[`dedent works with removing same number of spaces 1`] = `
 "first
    second

--- a/__tests__/dedent-tests.js
+++ b/__tests__/dedent-tests.js
@@ -19,6 +19,21 @@ describe("dedent", () => {
     ).toMatchSnapshot();
   });
 
+  it("works with newlines in interpolation", () => {
+    let interp1 = dd`second
+                       third
+                     fourth`;
+    let interp2 = dd`fifth again
+                       sixth
+                     seventh`;
+    expect(
+      dd`first
+         ${interp1}
+         fifth ${interp2}
+         eighth`
+    ).toMatchSnapshot();
+  });
+
   it("works with suppressed newlines", () => {
     expect(
       dd`first \

--- a/dedent.js
+++ b/dedent.js
@@ -21,7 +21,9 @@ export default function dedent(
       .replace(/\\\{/g, "{");
 
     if (i < values.length) {
-      result += values[i];
+      const lastLine = result.substring(result.lastIndexOf('\n') + 1);
+      const m = lastLine.match(/^(\s*)\S?/);
+      result += values[i].replace(/\n/g, '\n' + m[1]);
     }
   }
 


### PR DESCRIPTION
Fixes issue #165. Tagging @adrianjost since you said you had a notification blindspot.

Adds a couple lines of code to check for the indentation level of the current line in the string, and apply that same indentation to any newlines found in the expression arguments. Also adds a unit test which covers cases where an expression with internal `\n`s is inserted at a new line as well as mid-line.

That is, inserting an expression `a` here:

```
a = dedent`2
             3
           4`;

b = `1
     ${a}
     5`;
```

Is handled like this:
 
```      
b = `1
     2
       3
     4
     5`;
```
Instead of this:
```      
b = `1
     2
  3
4
     5`;
```