### PR TITLE
Fix v10.0.0 regression causing non-string interpolated values to crash

### DIFF
--- a/__tests__/__snapshots__/dedent-tests.js.snap
+++ b/__tests__/__snapshots__/dedent-tests.js.snap
@@ -60,6 +60,16 @@ seventh
 eighth"
 `;
 
+exports[`dedent works with non-string values in interpolation 1`] = `
+"first
+2
+undefined
+null
+true
+[object Object]
+third"
+`;
+
 exports[`dedent works with removing same number of spaces 1`] = `
 "first
    second

--- a/__tests__/dedent-tests.js
+++ b/__tests__/dedent-tests.js
@@ -34,6 +34,23 @@ describe("dedent", () => {
     ).toMatchSnapshot();
   });
 
+  it("works with non-string values in interpolation", () => {
+    let interp1 = 2;
+    let interp2 = undefined;
+    let interp3 = null;
+    let interp4 = true;
+    let interp5 = {myObj : "myObj"};
+    expect(
+      dd`first
+         ${interp1}
+         ${interp2}
+         ${interp3}
+         ${interp4}
+         ${interp5}
+         third`
+    ).toMatchSnapshot();
+  });
+
   it("works with suppressed newlines", () => {
     expect(
       dd`first \

--- a/dedent.js
+++ b/dedent.js
@@ -23,7 +23,7 @@ export default function dedent(
     if (i < values.length) {
       const lastLine = result.substring(result.lastIndexOf('\n') + 1);
       const m = lastLine.match(/^(\s*)\S?/);
-      result += values[i].replace(/\n/g, '\n' + m[1]);
+      result += values[i].toString().replace(/\n/g, '\n' + m[1]);
     }
   }
 

--- a/dedent.js
+++ b/dedent.js
@@ -23,7 +23,7 @@ export default function dedent(
     if (i < values.length) {
       const lastLine = result.substring(result.lastIndexOf('\n') + 1);
       const m = lastLine.match(/^(\s*)\S?/);
-      result += values[i].toString().replace(/\n/g, '\n' + m[1]);
+      result += String(values[i]).replace(/\n/g, '\n' + m[1]);
     }
   }
 


### PR DESCRIPTION
@adrianjost Just a heads up, found a crashing bug on my recent PR. Quick fix; could you take a look?

If `values[i]` is not a string, `.replace` does not exist for that object. This ensures the conversion to a string before attempting to replace the contents.